### PR TITLE
Release true-name version 0.2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this library will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this library adheres to Haskell's notion of the 
+[Package Versioning Policy (PVP)](https://pvp.haskell.org/).
+
+## [0.2.0.0] - 2024-05-16
+
+This release removes official support for GHC versions prior to `7.10.3`, and is
+hence a major-version change according to the Package Versioning Policy.
+
+### Added
+- Added support for GHC versions up to `9.8.x` and template-haskell versions 
+  up to `2.21.x`
+
+### Removed
+- Removed support for old GHC versions prior to `7.10.3`

--- a/true-name.cabal
+++ b/true-name.cabal
@@ -1,7 +1,7 @@
 cabal-version:  3.0
 
 name:           true-name
-version:        0.1.0.4
+version:        0.2.0.0
 synopsis:       Template Haskell hack to violate module abstractions
 description:
     <http://tvtropes.org/pmwiki/pmwiki.php/Main/IKnowYourTrueName Knowing a true name gives one power over its owner>.


### PR DESCRIPTION
This release removes official support for GHC versions prior to `7.10.3`, and is hence a major-version change according to the Package Versioning Policy.